### PR TITLE
Create home for vro-plugin-user

### DIFF
--- a/modules/vro_plugin_user/manifests/init.pp
+++ b/modules/vro_plugin_user/manifests/init.pp
@@ -30,9 +30,10 @@ class vro_plugin_user (
 ##Create system user.
 
   user { $vro_plugin_user:
-    ensure   => present,
-    shell    => '/bin/bash',
-    password => $vro_password_hash,
+    ensure     => present,
+    shell      => '/bin/bash',
+    password   => $vro_password_hash,
+    managehome => true,
   }
 
 ## Manage /etc/sudoers.d/vro-plugin-user file.  This allows and disallows sudo commands.


### PR DESCRIPTION
It looks like we need the home for the vro-plugin-user to be able to retrieve the list of environments and roles from the PE server:

Logs from the Orchestrator

```
2017-05-24 09:32:20.133+0000 vco: [component="SCRIPTING_LOG" priority="INFO" thread="http-nio-127.0.0.1-8280-exec-4" user="configurationadmin@vsphere.local" context="" token="" wfid="" wfname="" anctoken="" wfstac
k="" instanceid=""] [script: com.puppet.o11n.plugin.puppet/getEnvironments] (com.puppet.o11n.plugin.puppet/getEnvironments) Looking up environments on puppet.mgmt.infocert.it
2017-05-24 09:32:20.186+0000 vco: [component="ScriptModuleRuntimeServiceImpl" priority="WARN" thread="http-nio-127.0.0.1-8280-exec-4" user="" context="" token="" wfid="" wfname="" anctoken="" wfstack="" instanceid
=""] Unable to execute action class ch.dunes.util.DunesServerException: Failed to get list of environments from master. exitCode=0 error=Could not chdir to home directory /home/vro-plugin-user: No such file or dir
ectory
 (unnamed script#31)
2017-05-24 09:32:20.186+0000 vco: [component="BaseController" priority="ERROR" thread="http-nio-127.0.0.1-8280-exec-4" user="" context="" token="" wfid="" wfname="" anctoken="" wfstack="" instanceid=""] Error invo
king REST [unknown]
ch.dunes.util.DunesServerException: Action 'getEnvironments' in module 'com.puppet.o11n.plugin.puppet' failed : Failed to get list of environments from master. exitCode=0 error=Could not chdir to home directory /h
ome/vro-plugin-user: No such file or directory
 (unnamed script#31)
        at com.vmware.o11n.service.impl.ScriptModuleRuntimeServiceImpl.executeServerAction(ScriptModuleRuntimeServiceImpl.java:58)
        at c

```