### PR TITLE
Autosign script improvements

### DIFF
--- a/modules/autosign_example/manifests/init.pp
+++ b/modules/autosign_example/manifests/init.pp
@@ -1,6 +1,8 @@
-class autosign_example (String $puppet_autosign_shared_secret = "S3cr3tP@ssw0rd!") {
+class autosign_example (
+  String $puppet_autosign_shared_secret = 'S3cr3tP@ssw0rd!',
+) {
 
-  file { '/etc/puppetlabs/puppet/autosign.rb' :
+  file { '/etc/puppetlabs/puppet/autosign.rb':
     ensure  => file,
     owner   => 'pe-puppet',
     group   => 'pe-puppet',

--- a/modules/autosign_example/templates/autosign.rb.erb
+++ b/modules/autosign_example/templates/autosign.rb.erb
@@ -1,17 +1,33 @@
 #!/opt/puppetlabs/puppet/bin/ruby
-
+#
+# A note on logging:
+#   This script's stderr and stdout are only shown at the DEBUG level
+#   of the master's logs. This means you won't see the error messages
+#   in puppetserver.log by default. All you'll see is the exit code.
+#
+#   https://docs.puppet.com/puppet/latest/ssl_autosign.html#policy-executable-api
+#
+# Exit Codes:
+#   0 - A matching challengePassword was found.
+#   1 - No challengePassword was found.
+#   2 - The wrong challengePassword was found.
+#
 require 'puppet/ssl'
 
 csr = Puppet::SSL::CertificateRequest.from_s(STDIN.read)
 valid_pass = '<%= @puppet_autosign_shared_secret %>'
 
-csr_pass = csr.custom_attributes.find do |a|
-  a['oid'] == 'challengePassword' or
-  a['oid'] == '1.2.840.113549.1.9.7'
+if pass = csr.custom_attributes.find do |attribute|
+     ['challengePassword', '1.2.840.113549.1.9.7'].include? attribute['oid']
+   end
+else
+  puts 'No challengePassword found. Not automatically accepting the request.'
+  exit 1
 end
 
-if csr_pass['value'] == valid_pass
+if pass['value'] == valid_pass
   exit 0
 else
-  exit 1
+  puts "challengePassword does not match: #{pass['value']}"
+  exit 2
 end


### PR DESCRIPTION
Prior to this, the autosign script exited either 0 or 1. When exiting 1,
it wasn't clear why the script rejected the certificate.

This commit improves the autosign script by adding additional exit codes
based on the reason for success or failure:

Exit Codes:
  0 - A matching challengePassword was found.
  1 - No challengePassword was found.
  2 - The wrong challengePassword was found.

ping @jpadams