### PR TITLE
Update vra_nc_setup.sh

### DIFF
--- a/scripts/vra_nc_setup.sh
+++ b/scripts/vra_nc_setup.sh
@@ -62,7 +62,7 @@ error_checking()
   --cert   $cert \
   --key    $key \
   --cacert $cacert \
-  "https://$master_hostname:4433/classifier-api/v1/groups" | grep -q code_manager_auto_configure
+  "https://$master_hostname:4433/classifier-api/v1/groups" | grep -q code_manager_auto_configure..true
   if [ $? -eq 0 ]; then
     echo "ERROR: It appears that code manager is being used. This script cannot continue."
     echo "Instead, use desired modules from the Puppetfile and use in your own control-repo's Puppetfile."


### PR DESCRIPTION
Use case this PR addresses: 
If you stand up a new master for this integration (e.g. for a demo or POC setup), and if it has code manager running by default, a good way to disable it is by changing the value of code_manager_auto_configure from true to false via the console UI. However, the vra_nc_setup.sh script will still think that code manager manager is running. 

Proposed fix: 
This change tells the script that if code_manager_auto_configure = false then code manager is not running and it's ok to continue.   --Eric
